### PR TITLE
ssh key test: skip blank lines and comment lines in authorized_keys t…

### DIFF
--- a/tests/001_SSH_Perm.py
+++ b/tests/001_SSH_Perm.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from TestBase import TestBase 
 from util       import run_cmd, capture
-import stat, os
+import stat, os, getpass
 
 class SSH_Perm(TestBase):
   
@@ -67,15 +67,13 @@ class SSH_Perm(TestBase):
   def execute(self):
     result = True
 
- #  home = os.environ['HOME']
-    userid=capture("whoami").rstrip()
- #  grepcmd="grep %s /etc/passwd | cut -d ':' -f6" %userid
-    grepcmd="/bin/awk -F: -v user=%s '$1 == user {print $6}' </etc/passwd" %userid
-    home=capture(grepcmd)
+    home=os.path.expanduser('~')
+
+    userid=getpass.getuser()
+
     if not home:
         self.error_message+="\tError: Your home directory is inaccessible!\n"
         return False
-    home=home[:-1]
 
     sshD = os.path.join(home,".ssh")
     dirA = [ home, sshD ]

--- a/tests/002_SSH_key.py
+++ b/tests/002_SSH_key.py
@@ -35,7 +35,8 @@ class SSH_key(TestBase):
       self.error_message+="\tError: ~/.ssh/id_rsa.pub not found in ~/.ssh/authorized_keys.\n"
       return False 
 
-    cmd2    ="awk '{if ($1!=\"ssh-dss\" && $1!=\"ssh-rsa\" || NF <= 1) print $0}' ~/.ssh/authorized_keys"
+    # skip blank lines and comment lines
+    cmd2    ="awk '(length($0) && ($0 !~ \"^#\")) {if ($1!=\"ssh-dss\" && $1!=\"ssh-rsa\" || NF <= 1) print $0}' ~/.ssh/authorized_keys"
     cmd2_out = capture(cmd2)
     if cmd2_out:
 	self.error_message+="\tError: ~/.ssh/authorized_keys includes invalid or broken key(s).\n"

--- a/tests/004_Block_User.py
+++ b/tests/004_Block_User.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from TestBase   import TestBase
 from util       import run_cmd, capture,syshost
+import getpass
+
 class Block_User(TestBase):
  
   error_message=""
@@ -28,7 +30,7 @@ class Block_User(TestBase):
     if host!="stampede":
       return True
 
-    userid=capture("whoami").rstrip()
+    userid=getpass.getuser()
     
     grepcmd1="""awk '/ALL = /,/ALL = /' /etc/slurm/tacc_filter_options | awk '{print substr($0,7,length($0)-7)}' | awk -v user=%s 'BEGIN {FS=" !!"}; {for (i=1; i<=NF; i++) if($i == user) {print $0}}'""" %userid      
 #    print(grepcmd1)

--- a/tests/005_Allocation.py
+++ b/tests/005_Allocation.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from TestBase   import TestBase
 from util       import run_cmd, capture,syshost
 from datetime import *
+import getpass
 
 class Allocation(TestBase):
   
@@ -26,7 +27,7 @@ class Allocation(TestBase):
     print("\tPlease renew your allocations.\n")
 
   def execute(self):
-      userid=capture("whoami").rstrip()
+      userid=getpass.getuser()
 ###   userid="jkatzene"      #Fake test 
       
       host=syshost()

--- a/tests/006_Quota.py
+++ b/tests/006_Quota.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from TestBase   import TestBase
 from util       import run_cmd, capture,syshost
+import getpass
 
 class Quota(TestBase):
   
@@ -25,7 +26,7 @@ class Quota(TestBase):
       print("\tPlease remove unnecessary files to clean your spaces.\n")
 
   def execute(self):
-      userid=capture("whoami").rstrip()
+      userid=getpass.getuser()
       host=syshost()
      
       if (host=="stampede" or host=="ls5"):


### PR DESCRIPTION
…o prevent false negatives

I had some old and test keys commented out, and it gave an error. They should be ignored.